### PR TITLE
Fixing compilation error on newer glibc

### DIFF
--- a/src/AS_BAT/memoryMappedFile.H
+++ b/src/AS_BAT/memoryMappedFile.H
@@ -26,7 +26,10 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
+
+#ifdef HW_PHYSMEM
 #include <sys/sysctl.h>
+#endif
 
 #include <set>
 #include <map>


### PR DESCRIPTION
Glibc newer than 2.32 removes that include file. Additionally since kernel version 5.5 the sysctl function has returned ENOSYS. So likely it should be removed entirely, but all this PR does is add the same guard to the include as the function that uses the sysctl function.